### PR TITLE
fix: cjson pc name

### DIFF
--- a/cjson/cjson_autogen_link.go
+++ b/cjson/cjson_autogen_link.go
@@ -1,3 +1,3 @@
 package cjson
 
-const LLGoPackage string = "link: $(pkg-config --libs libcjson libcjson_utils);"
+const LLGoPackage string = "link: $(pkg-config --libs cjson);"

--- a/cjson/llcppg.cfg
+++ b/cjson/llcppg.cfg
@@ -1,7 +1,7 @@
 {
 	"name": "cjson",
-	"cflags": "$(pkg-config --cflags libcjson)",
-	"libs": "$(pkg-config --libs libcjson libcjson_utils)",
+	"cflags": "$(pkg-config --cflags cjson)",
+	"libs": "$(pkg-config --libs cjson)",
 	"include": [
 		"cjson/cJSON.h",
 		"cjson/cJSON_Utils.h"


### PR DESCRIPTION
current pc name for `cjson` is just `cjson`, not the other, which passed the test in https://github.com/MeteorsLiu/llpkg/blob/main/cjson/llcppg.cfg