### PR TITLE
chore(ci): migrate from `macos-13` to `macos-15-intel` runner

### DIFF
--- a/.github/workflows/postprocessing.yml
+++ b/.github/workflows/postprocessing.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - macos-13
+          - macos-15-intel
           - macos-latest
           - ubuntu-24.04
           - ubuntu-24.04-arm

--- a/.github/workflows/verification.yml
+++ b/.github/workflows/verification.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os:
-          - macos-13
+          - macos-15-intel
           - macos-latest
           - ubuntu-24.04
           - ubuntu-24.04-arm


### PR DESCRIPTION
GitHub announced the deprecation of the `macos-13` runner image[^1], which will be completely removed by December 4th, 2025.

This commit migrates all workflows to use `macos-15-intel` runners following the announcement's recommendation.

[^1]: https://github.blog/changelog/2025-09-19-github-actions-macos-13-runner-image-is-closing-down/